### PR TITLE
MrHyDE Docker container

### DIFF
--- a/scripts/docker/Dockerfile
+++ b/scripts/docker/Dockerfile
@@ -1,0 +1,59 @@
+FROM --platform=linux/amd64 silkeh/clang:12
+WORKDIR /git-repos
+
+# Make sure basic necessities are installed
+RUN apt-get update && apt-get install -y wget zip unzip xz-utils bzip2 zlib1g-dev libblas-dev liblapack-dev ssh
+
+# Install CMake
+RUN wget https://github.com/Kitware/CMake/releases/download/v3.23.1/cmake-3.23.1-linux-x86_64.tar.gz && \
+    tar xf cmake-3.23.1-linux-x86_64.tar.gz && \
+    rm cmake-3.23.1-linux-x86_64.tar.gz && \
+    mv cmake-3.23.1-linux-x86_64 /usr/local/cmake && \
+    ln -s /usr/local/cmake/bin/cmake /usr/local/bin/cmake
+
+# Install Ninja
+RUN wget https://github.com/ninja-build/ninja/releases/download/v1.10.2/ninja-linux.zip && \
+    unzip ninja-linux.zip && rm ninja-linux.zip && \
+    mv ninja /usr/local/bin
+
+# Configure and install OpenMPI
+RUN wget https://download.open-mpi.org/release/open-mpi/v4.1/openmpi-4.1.2.tar.gz && \
+    tar xf openmpi-4.1.2.tar.gz && rm openmpi-4.1.2.tar.gz && \
+    cd openmpi-4.1.2 && \
+    ./configure CC=clang CXX=clang++ --prefix=/usr/local && \
+    make -j $(nproc) && \
+    make install && ldconfig && \
+    echo "export OMPI_ALLOW_RUN_AS_ROOT=1" >> ~/.bashrc && \
+    echo "export OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1" >> ~/.bashrc
+
+# Configure and install Boost
+RUN wget https://boostorg.jfrog.io/artifactory/main/release/1.79.0/source/boost_1_79_0.tar.gz && \
+    tar xf boost_1_79_0.tar.gz && rm boost_1_79_0.tar.gz && \
+    cd boost_1_79_0 && \
+    ./bootstrap.sh --with-toolset=clang && \
+    echo "using mpi ;" >> project-config.jam && \
+    ./b2 -j $(nproc) && ./b2 install --prefix=/usr/local
+
+# Configure and install HDF5
+RUN wget https://github.com/HDFGroup/hdf5/releases/download/hdf5-1_10_11/hdf5-1_10_11.tar.gz && \
+    tar xf hdf5-1_10_11.tar.gz && rm hdf5-1_10_11.tar.gz && cd hdfsrc && \
+    CC=mpicc CFLAGS=-fPIC ./configure --enable-shared --enable-parallel --prefix=/usr/local && \
+    make -j $(nproc) && make install
+
+# Configure and install netcdf-c
+RUN wget https://github.com/Unidata/netcdf-c/archive/refs/tags/v4.8.1.tar.gz && \
+    tar xf v4.8.1.tar.gz && cd netcdf-c-4.8.1 && \
+    CC=mpicc LIBS=-lhdf5 ./configure --prefix=/usr/local && \
+    make -j $(nproc) && make install
+
+# Configure and build/install Trilinos
+COPY config_trilinos.sh /root/config_trilinos.sh
+
+RUN wget https://github.com/trilinos/Trilinos/archive/refs/tags/trilinos-release-14-4-0.tar.gz && \
+    tar xf trilinos-release-14-4-0.tar.gz && \
+    rm trilinos-release-14-4-0.tar.gz && \
+    mv Trilinos-trilinos-release-14-4-0 Trilinos && \
+    mkdir Trilinos/build && cd Trilinos/build && \
+    export TRILINOS_HOME='/git-repos/Trilinos' && \
+    bash /root/config_trilinos.sh && \
+    ninja && cmake --install .

--- a/scripts/docker/README
+++ b/scripts/docker/README
@@ -1,0 +1,46 @@
+# Building a MrHyDE Docker Container
+
+This folder contains a `Dockerfile` which builds all the _dependencies_ of MrHyDE (though, notably, currently _does not build MrHyDE itself_). This is intended to be used for working with a serial implementation of MrHyDE and, as such, does not compile Trilinos with OpenMP or other possible parallel bindings. The reason MrHyDE is not incorporated here is that any changes to the repository (which you have presumably already cloned) should be represented on the host and not lost in the docker container, i.e., this repository should be mounted as a docker volume.
+
+## How to use
+First, ensure that `docker engine` is installed (see instructions [here](https://docs.docker.com/engine/install/)).
+
+There is currently a built version that one can use via `docker pull dgsharp/mrhyde:serial_dev`. Then, assuming that your path to this repository (i.e., to the base directory of the repository) is set as `$MRHYDE_SRC`. Then, you can execute 
+
+```
+docker run -itd -v $MRHYDE_SRC:/git-repos/MrHyDE dgsharp/mrhyde:serial_dev
+```
+
+This command will echo out a long `SHA` string (`Digest: sha256:<YOUR SHA>`) and spawn a container (that will run until you `stop` it), which contains your git repository mounted at `/git-repos/MrHyDE`; any changes you make on your host at `$MRHYDE_SRC` will be reflected in real time in the container, and vice versa.
+
+## Using this image
+### Shell usage
+One possible workflow is to open up your preferred IDE and edit MrHyDE as needed. Then, when you want to test changes, run
+```
+docker exec -it <YOUR SHA> bash
+```
+where `<YOUR SHA>` should match the above (or just take the first four or so characters). This will open up a terminal *within* the container. Then, one can do, e.g.
+```
+$ mkdir /git-repos/MrHyDE/build
+$ cd /git-repos/MrHyDE/build
+$ cmake \
+    -D CMAKE_CXX_STANDARD=17 \
+    -GNinja \
+    -DTrilinos_SRC_DIR=/git-repos/Trilinos/ \
+    -DTrilinos_INSTALL_DIR=/usr/local \
+    -DCMAKE_CXX_FLAGS=" -Wall" \
+    ..
+$ cd ../regression
+$ ln -s ../build/src/mrhyde
+$ ./runtests.py
+```
+
+### VS Code
+If your preferred editor is VS Code, you can use the [`Dockerfile`](https://containers.dev/guide/dockerfile#dockerfile) or the [image on Docker Hub](https://code.visualstudio.com/docs/devcontainers/tutorial#:~:text=devcontainer.json,-The%20devcontainer.&text=The%20above%20example%20is%20extracted,we%20used%20in%20the%20tutorial.&text=The%20name%20of%20an%20image,to%20create%20the%20dev%20container.) to configure a dev container using the Remote: Dev Containers extension
+
+## Notes
+### Dev notes
+If you are interested in changing the dependencies (e.g., compiling using a version of Trilinos with OpenMP/GPU compatibility) then, assuming your shell is in this directory, you can change the Trilinos config in `config_trilinos.sh` and add any necessary dependencies in the `Dockerfile`. Then, run `docker build .`
+
+### TODO
+This Docker container is known to fail the `porous/Mixed_hybrid_highorder` test. The cause of this failure is currently unknown.

--- a/scripts/docker/config_trilinos.sh
+++ b/scripts/docker/config_trilinos.sh
@@ -1,0 +1,29 @@
+cmake \
+    -G Ninja \
+    -D CMAKE_C_COMPILER:FILEPATH=mpicc \
+    -D CMAKE_CXX_COMPILER:FILEPATH=mpic++ \
+    -D PYTHON_EXECUTABLE:FILEPATH=python3 \
+    -D CMAKE_BUILD_TYPE:STRING=RELEASE \
+    -D CMAKE_CXX_FLAGS:STRING=" -O3 -DNDEBUG" \
+    -D TPL_ENABLE_MPI:BOOL=ON \
+    -D TPL_ENABLE_Boost=ON \
+    -D TPL_ENABLE_Matio=OFF \
+    -D BUILD_SHARED_LIBS:BOOL=ON \
+    -D Trilinos_ENABLE_EXPLICIT_INSTANTIATION:BOOL=ON \
+    -D Trilinos_ENABLE_CHECKED_STL:BOOL=OFF \
+    -D Trilinos_ENABLE_Fortran=OFF \
+    -D Trilinos_ENABLE_TriKota:BOOL=OFF \
+    -D Trilinos_ENABLE_Stokhos:BOOL=OFF \
+    -D Trilinos_ENABLE_Belos:BOOL=ON \
+    -D Trilinos_ENABLE_ROL:BOOL=ON \
+    -D Trilinos_ENABLE_PanzerDofMgr=ON \
+    -D Trilinos_ENABLE_PanzerMiniEM=OFF \
+    -D Trilinos_ENABLE_PanzerAdaptersSTK=ON \
+    -D Trilinos_ENABLE_Intrepid2:BOOL=ON \
+    -D Trilinos_ENABLE_Shards:BOOL=ON \
+    -D Trilinos_ENABLE_Amesos2:BOOL=ON \
+    -D Trilinos_ENABLE_MueLu:BOOL=ON \
+    -D Trilinos_ENABLE_Percept:BOOL=OFF \
+    -D Trilinos_ENABLE_Compadre:BOOL=ON \
+    -D Tpetra_SHOW_DEPRECATED_WARNINGS=OFF \
+    ..


### PR DESCRIPTION
As referenced in #1 , I've been trying to get MrHyDE working in a docker container (so that people who want to try it out don't have to fuss too much about getting all these random things installed just right, while littering in system paths, dealing with multiple installs of Trilinos, etc). This includes a new folder in the `scripts` directory which has a working `Dockerfile` as well as a `README` on how to use it.

NOTES:
- Admittedly, I link to an image I pushed onto Docker Hub under `dgsharp/mrhyde:serial_dev` (which is obviously under my name, not clearly associated under Sandia). If that's a problem please let me know. However, the only thing in that image is just some libraries that are all open source and nothing crazy.
- If you use the image to build MrHyDE, one of the tests fails. In particular, `porous/Mixed_hybrid_highorder`. I haven't checked why this happens, but I figure 120/121 regression tests passing is a good start.

Hopefully, with the public release of MrHyDE, this will make development and usage of MrHyDE from the public much more tractable (at least, it will for me). One simple further step would be to create an image that actually `bundles` MrHyDE prebuilt with the image. However, unless and until MrHyDE is a library, actually including it prebuilt in the image isn't particularly useful.