### PR TITLE
Add shared library option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ cmake_minimum_required(VERSION 2.8.12)
 # not every version of CMAKE uses the new version of policy CMP0057
 # this enforces it since Kokkos assumes the new version of the policy
 CMAKE_POLICY(SET CMP0057 NEW)
+CMAKE_POLICY(SET CMP0048 NEW)
 
 ENABLE_TESTING()
 
@@ -16,7 +17,25 @@ set(CMAKE_PREFIX_PATH ${TRILINOS_DIR} ${CMAKE_PREFIX_PATH})
 #PROJECT(mrhyde)
 project(mrhyde
   LANGUAGES NONE  # Defined below after reading in compilers
+  VERSION 0.1.0
 )
+
+# See https://gist.github.com/kprussing/db21614ca5b51cedff07dfb70059f280
+# use, i.e. don't skip full RPATH for the build tree
+set(CMAKE_SKIP_BUILD_RPATH FALSE)
+
+# when building, don't use the install RPATH already
+# (but later on when installing)
+set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
+
+set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+
+# add the automatically determined parts of the RPATH
+# which point to directories outside the build tree to the install RPATH
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+
+# the RPATH to be used when installing, but only if it's not a system directory
+list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_PREFIX/lib}" isSystemDir)
 
 find_package(Trilinos REQUIRED)
 
@@ -257,7 +276,42 @@ ENDIF()
 IF(MrHyDE_ENABLE_UNIT_TESTS)
   ADD_SUBDIRECTORY(unit_tests)
 ENDIF()
-  
+
+install(TARGETS mrhyde_lib
+  EXPORT mrhydeTargets
+  DESTINATION lib)
+include(CMakePackageConfigHelpers)
+configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/Config.cmake.in
+    "${CMAKE_CURRENT_BINARY_DIR}/Config.cmake"
+    INSTALL_DESTINATION "${CMAKE_INSTALL_PREFIX}/lib/cmake"
+    NO_SET_AND_CHECK_MACRO
+    NO_CHECK_REQUIRED_COMPONENTS_MACRO
+)
+
+write_basic_package_version_file(
+    "${CMAKE_CURRENT_BINARY_DIR}/ConfigVersion.cmake"
+    VERSION "${PROJECT_VERSION}"
+    COMPATIBILITY SameMajorVersion
+)
+
+install(FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/Config.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/ConfigVersion.cmake
+    DESTINATION lib/cmake/mrhyde
+)
+
+export(TARGETS mrhyde_lib ${KOKKOS_EXPORTS} NAMESPACE mrhyde:: FILE mrhydeTargets.cmake)
+export(PACKAGE mrhyde)
+
+install(EXPORT mrhydeTargets NAMESPACE mrhyde:: DESTINATION lib/cmake/mrhyde)
+
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/Config.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/ConfigVersion.cmake
+    DESTINATION lib/cmake/mrhyde_lib
+)
+
+export(TARGETS mrhyde_lib FILE Config.cmake)
+
 #INSTALL(
 #    DIRECTORY ""
 #    DESTINATION ""

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,18 +21,18 @@ project(mrhyde
 )
 
 # See https://gist.github.com/kprussing/db21614ca5b51cedff07dfb70059f280
-# use, i.e. don't skip full RPATH for the build tree
-set(CMAKE_SKIP_BUILD_RPATH FALSE)
+# # use, i.e. don't skip full RPATH for the build tree
+# set_target_properties(mrhyde_lib CMAKE_SKIP_BUILD_RPATH FALSE)
 
-# when building, don't use the install RPATH already
-# (but later on when installing)
-set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
+# # when building, don't use the install RPATH already
+# # (but later on when installing)
+# set_target_properties(mrhyde_lib CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
 
-set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+# set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
 
-# add the automatically determined parts of the RPATH
-# which point to directories outside the build tree to the install RPATH
-set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+# # add the automatically determined parts of the RPATH
+# # which point to directories outside the build tree to the install RPATH
+# set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
 # the RPATH to be used when installing, but only if it's not a system directory
 list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_PREFIX/lib}" isSystemDir)
@@ -278,39 +278,33 @@ IF(MrHyDE_ENABLE_UNIT_TESTS)
 ENDIF()
 
 install(TARGETS mrhyde_lib
-  EXPORT mrhydeTargets
+  EXPORT MrHyDETargets
   DESTINATION lib)
+
 include(CMakePackageConfigHelpers)
 configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/Config.cmake.in
-    "${CMAKE_CURRENT_BINARY_DIR}/Config.cmake"
-    INSTALL_DESTINATION "${CMAKE_INSTALL_PREFIX}/lib/cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/MrHyDEConfig.cmake"
+    INSTALL_DESTINATION "${CMAKE_INSTALL_PREFIX}/lib/MrHyDEcmake"
     NO_SET_AND_CHECK_MACRO
     NO_CHECK_REQUIRED_COMPONENTS_MACRO
 )
 
 write_basic_package_version_file(
-    "${CMAKE_CURRENT_BINARY_DIR}/ConfigVersion.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/MrHyDEConfigVersion.cmake"
     VERSION "${PROJECT_VERSION}"
     COMPATIBILITY SameMajorVersion
 )
 
 install(FILES
-    ${CMAKE_CURRENT_BINARY_DIR}/Config.cmake
-    ${CMAKE_CURRENT_BINARY_DIR}/ConfigVersion.cmake
-    DESTINATION lib/cmake/mrhyde
+    ${CMAKE_CURRENT_BINARY_DIR}/MrHyDEConfig.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/MrHyDEConfigVersion.cmake
+    DESTINATION lib/cmake/MrHyDE
 )
 
-export(TARGETS mrhyde_lib ${KOKKOS_EXPORTS} NAMESPACE mrhyde:: FILE mrhydeTargets.cmake)
-export(PACKAGE mrhyde)
+export(TARGETS mrhyde_lib NAMESPACE MrHyDE:: FILE MrHyDETargets.cmake)
+export(PACKAGE MrHyDE)
 
-install(EXPORT mrhydeTargets NAMESPACE mrhyde:: DESTINATION lib/cmake/mrhyde)
-
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/Config.cmake
-    ${CMAKE_CURRENT_BINARY_DIR}/ConfigVersion.cmake
-    DESTINATION lib/cmake/mrhyde_lib
-)
-
-export(TARGETS mrhyde_lib FILE Config.cmake)
+install(EXPORT MrHyDETargets NAMESPACE MrHyDE:: DESTINATION lib/cmake/MrHyDE)
 
 #INSTALL(
 #    DIRECTORY ""

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ ENABLE_TESTING()
 
 SET(TRILINOS_DIR ${Trilinos_INSTALL_DIR})
 SET(Trilinos_SRC_DIR ${Trilinos_SRC_DIR})
+option(MrHyDE_BUILD_SHARED_LIBS "Build MrHyDE with shared libraries." ON)
 
 set(CMAKE_PREFIX_PATH ${TRILINOS_DIR} ${CMAKE_PREFIX_PATH})
 
@@ -62,6 +63,7 @@ IF(Trilinos_VERSION LESS 14.0) # GH: if a version is not detected, CMake default
 ELSE()
   MESSAGE("   Trilinos_VERSION >= 14 detected, using new names for Tpetra::KokkosCompat objects")
   ADD_DEFINITIONS(-DMrHyDE_HAVE_TRILINOS14)
+  set(MrHyDE_HAVE_TRILINOS14 TRUE)
 ENDIF()
 MESSAGE("End of Trilinos details\n")
 
@@ -277,34 +279,46 @@ IF(MrHyDE_ENABLE_UNIT_TESTS)
   ADD_SUBDIRECTORY(unit_tests)
 ENDIF()
 
-install(TARGETS mrhyde_lib
-  EXPORT MrHyDETargets
-  DESTINATION lib)
+IF(MrHyDE_BUILD_SHARED_LIBS)
 
-include(CMakePackageConfigHelpers)
-configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/Config.cmake.in
-    "${CMAKE_CURRENT_BINARY_DIR}/MrHyDEConfig.cmake"
-    INSTALL_DESTINATION "${CMAKE_INSTALL_PREFIX}/lib/MrHyDEcmake"
-    NO_SET_AND_CHECK_MACRO
-    NO_CHECK_REQUIRED_COMPONENTS_MACRO
-)
+  # Add necessary definitions here
+  IF(MrHyDE_HAVE_TRILINOS14)
+    target_compile_definitions(mrhyde_lib PUBLIC MrHyDE_HAVE_TRILINOS14)
+  ENDIF()
 
-write_basic_package_version_file(
-    "${CMAKE_CURRENT_BINARY_DIR}/MrHyDEConfigVersion.cmake"
-    VERSION "${PROJECT_VERSION}"
-    COMPATIBILITY SameMajorVersion
-)
 
-install(FILES
-    ${CMAKE_CURRENT_BINARY_DIR}/MrHyDEConfig.cmake
-    ${CMAKE_CURRENT_BINARY_DIR}/MrHyDEConfigVersion.cmake
-    DESTINATION lib/cmake/MrHyDE
-)
+  # Install the shared library object targets
+  install(TARGETS mrhyde_lib
+    EXPORT MrHyDETargets
+    DESTINATION lib)
 
-export(TARGETS mrhyde_lib NAMESPACE MrHyDE:: FILE MrHyDETargets.cmake)
-export(PACKAGE MrHyDE)
+  # Configure the CMake packaging
+  include(CMakePackageConfigHelpers)
+  configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/Config.cmake.in
+      "${CMAKE_CURRENT_BINARY_DIR}/MrHyDEConfig.cmake"
+      INSTALL_DESTINATION "${CMAKE_INSTALL_PREFIX}/lib/MrHyDEcmake"
+      NO_SET_AND_CHECK_MACRO
+      NO_CHECK_REQUIRED_COMPONENTS_MACRO
+  )
 
-install(EXPORT MrHyDETargets NAMESPACE MrHyDE:: DESTINATION lib/cmake/MrHyDE)
+  write_basic_package_version_file(
+      "${CMAKE_CURRENT_BINARY_DIR}/MrHyDEConfigVersion.cmake"
+      VERSION "${PROJECT_VERSION}"
+      COMPATIBILITY SameMajorVersion
+  )
+
+  install(FILES
+      ${CMAKE_CURRENT_BINARY_DIR}/MrHyDEConfig.cmake
+      ${CMAKE_CURRENT_BINARY_DIR}/MrHyDEConfigVersion.cmake
+      DESTINATION lib/cmake/MrHyDE
+  )
+
+  export(TARGETS mrhyde_lib NAMESPACE MrHyDE:: FILE MrHyDETargets.cmake)
+  export(PACKAGE MrHyDE)
+
+  # Install the cmake configuration
+  install(EXPORT MrHyDETargets NAMESPACE MrHyDE:: DESTINATION lib/cmake/MrHyDE)
+ENDIF()
 
 #INSTALL(
 #    DIRECTORY ""

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,20 +21,6 @@ project(mrhyde
   VERSION 0.1.0
 )
 
-# See https://gist.github.com/kprussing/db21614ca5b51cedff07dfb70059f280
-# # use, i.e. don't skip full RPATH for the build tree
-# set_target_properties(mrhyde_lib CMAKE_SKIP_BUILD_RPATH FALSE)
-
-# # when building, don't use the install RPATH already
-# # (but later on when installing)
-# set_target_properties(mrhyde_lib CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
-
-# set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
-
-# # add the automatically determined parts of the RPATH
-# # which point to directories outside the build tree to the install RPATH
-# set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
-
 # the RPATH to be used when installing, but only if it's not a system directory
 list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_PREFIX/lib}" isSystemDir)
 

--- a/Config.cmake.in
+++ b/Config.cmake.in
@@ -1,0 +1,6 @@
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+find_dependency(Trilinos REQUIRED)
+
+include ( "${CMAKE_CURRENT_LIST_DIR}/MrHyDETargets.cmake" )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -55,16 +55,18 @@ ADD_EXECUTABLE(mrhyde
 )
 TARGET_LINK_LIBRARIES(mrhyde ${Trilinos_LIBRARIES} ${Trilinos_TPL_LIBRARIES}) 
 
-add_library(mrhyde_lib SHARED
-    ${mrhyde-all}
-)
-target_include_directories(mrhyde_lib PUBLIC
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
-  $<INSTALL_INTERFACE:include>
-)
-target_link_libraries(mrhyde_lib ${Trilinos_LIBRARIES} ${Trilinos_TPL_LIBRARIES})
-install(TARGETS mrhyde_lib DESTINATION lib/)
-install(DIRECTORY . DESTINATION include/ FILES_MATCHING PATTERN "*.hpp")
+IF(MrHyDE_BUILD_SHARED_LIBS)
+  add_library(mrhyde_lib SHARED
+      ${mrhyde-all}
+  )
+  target_include_directories(mrhyde_lib PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:include>
+  )
+  target_link_libraries(mrhyde_lib ${Trilinos_LIBRARIES} ${Trilinos_TPL_LIBRARIES})
+  install(TARGETS mrhyde_lib DESTINATION lib/)
+  install(DIRECTORY . DESTINATION include/ FILES_MATCHING PATTERN "*.hpp")
+ENDIF()
 
 IF(MrHyDE_ENABLE_XML_to_YAML)
   ADD_EXECUTABLE(xml_to_yaml

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -56,6 +56,13 @@ ADD_EXECUTABLE(mrhyde
 
 TARGET_LINK_LIBRARIES(mrhyde ${Trilinos_LIBRARIES} ${Trilinos_TPL_LIBRARIES}) 
 
+add_library(mrhyde_lib SHARED
+    ${mrhyde-all}
+)
+target_include_directories(mrhyde_lib PUBLIC managers/*.hpp)
+target_link_libraries(mrhyde_lib ${Trilinos_LIBRARIES} ${Trilinos_TPL_LIBRARIES})
+install(TARGETS mrhyde_lib DESTINATION lib/)
+
 IF(MrHyDE_ENABLE_XML_to_YAML)
   ADD_EXECUTABLE(xml_to_yaml
   ../scripts/utils/xml_to_yaml.cpp)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -53,15 +53,18 @@ ENDIF()
 ADD_EXECUTABLE(mrhyde
   ${mrhyde-all}
 )
-
 TARGET_LINK_LIBRARIES(mrhyde ${Trilinos_LIBRARIES} ${Trilinos_TPL_LIBRARIES}) 
 
 add_library(mrhyde_lib SHARED
     ${mrhyde-all}
 )
-target_include_directories(mrhyde_lib PUBLIC managers/*.hpp)
+target_include_directories(mrhyde_lib PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+  $<INSTALL_INTERFACE:include>
+)
 target_link_libraries(mrhyde_lib ${Trilinos_LIBRARIES} ${Trilinos_TPL_LIBRARIES})
 install(TARGETS mrhyde_lib DESTINATION lib/)
+install(DIRECTORY . DESTINATION include/ FILES_MATCHING PATTERN "*.hpp")
 
 IF(MrHyDE_ENABLE_XML_to_YAML)
   ADD_EXECUTABLE(xml_to_yaml

--- a/src/interfaces/discretizationInterface.hpp
+++ b/src/interfaces/discretizationInterface.hpp
@@ -22,7 +22,7 @@
 #include "Panzer_STK_Interface.hpp"
 #include "physicsInterface.hpp"
 #include "meshInterface.hpp"
-#include "groupMetaData.hpp"
+#include "tools/groupMetaData.hpp"
 
 namespace MrHyDE {
   

--- a/src/interfaces/linearAlgebraInterface.hpp
+++ b/src/interfaces/linearAlgebraInterface.hpp
@@ -17,7 +17,7 @@
 #include "trilinos.hpp"
 #include "preferences.hpp"
 #include "discretizationInterface.hpp"
-#include "parameterManager.hpp"
+#include "managers/parameterManager.hpp"
 
 // Belos
 #include <BelosConfigDefs.hpp>

--- a/src/interfaces/meshInterface.hpp
+++ b/src/interfaces/meshInterface.hpp
@@ -26,12 +26,12 @@
 #include "Panzer_STK_Interface.hpp"
 #include "Panzer_STK_ExodusReaderFactory.hpp"
 #include "Panzer_STKConnManager.hpp"
-#include "simplemeshmanager.hpp"
+#include "tools/simplemeshmanager.hpp"
 
 #include "preferences.hpp"
 //#include "physicsInterface.hpp"
 //#include "group.hpp"
-#include "data.hpp"
+#include "tools/data.hpp"
 //#include "boundaryGroup.hpp"
 
 namespace MrHyDE {

--- a/src/interfaces/physicsInterface.hpp
+++ b/src/interfaces/physicsInterface.hpp
@@ -17,8 +17,8 @@
 #include "trilinos.hpp"
 #include "preferences.hpp"
 
-#include "physicsBase.hpp"
-#include "workset.hpp"
+#include "physics/physicsBase.hpp"
+#include "tools/workset.hpp"
 
 //#include "Panzer_STK_Interface.hpp"
 #include "Panzer_DOFManager.hpp"

--- a/src/managers/assemblyManager.hpp
+++ b/src/managers/assemblyManager.hpp
@@ -18,17 +18,19 @@
 #include "Panzer_DOFManager.hpp"
 
 #include "preferences.hpp"
-#include "groupMetaData.hpp"
-#include "group.hpp"
-#include "boundaryGroup.hpp"
-#include "workset.hpp"
-#include "meshInterface.hpp"
-#include "physicsInterface.hpp"
-#include "discretizationInterface.hpp"
+#include "tools/groupMetaData.hpp"
+#include "tools/group.hpp"
+#include "tools/boundaryGroup.hpp"
+#include "tools/workset.hpp"
+#include "tools/data.hpp"
+
+#include "interfaces/meshInterface.hpp"
+#include "interfaces/physicsInterface.hpp"
+#include "interfaces/discretizationInterface.hpp"
+
 #include "parameterManager.hpp"
 #include "multiscaleManager.hpp"
 #include "functionManager.hpp"
-#include "data.hpp"
 
 namespace MrHyDE {
   

--- a/src/managers/functionManager.hpp
+++ b/src/managers/functionManager.hpp
@@ -16,10 +16,10 @@
 
 #include "trilinos.hpp"
 #include "preferences.hpp"
-#include "dag.hpp"
-#include "interpreter.hpp"
-#include "workset.hpp"
-#include "vista.hpp"
+#include "tools/dag.hpp"
+#include "tools/interpreter.hpp"
+#include "tools/workset.hpp"
+#include "tools/vista.hpp"
 
 namespace MrHyDE {
   

--- a/src/managers/multiscaleManager.hpp
+++ b/src/managers/multiscaleManager.hpp
@@ -11,11 +11,11 @@
 
 #include "trilinos.hpp"
 #include "preferences.hpp"
-#include "group.hpp"
-#include "subgridModel.hpp"
+#include "tools/group.hpp"
+#include "subgrid/subgridModel.hpp"
 #include "Amesos2.hpp"
-#include "meshInterface.hpp"
-#include "workset.hpp"
+#include "interfaces/meshInterface.hpp"
+#include "tools/workset.hpp"
 
 namespace MrHyDE {
   

--- a/src/managers/parameterManager.hpp
+++ b/src/managers/parameterManager.hpp
@@ -11,13 +11,13 @@
 
 #include "trilinos.hpp"
 #include "preferences.hpp"
-#include "meshInterface.hpp"
-#include "physicsInterface.hpp"
-#include "group.hpp"
-#include "boundaryGroup.hpp"
+#include "interfaces/meshInterface.hpp"
+#include "interfaces/physicsInterface.hpp"
+#include "tools/group.hpp"
+#include "tools/boundaryGroup.hpp"
 #include "Panzer_STK_Interface.hpp"
-#include "discretizationInterface.hpp"
-#include "MrHyDE_OptVector.hpp"
+#include "interfaces/discretizationInterface.hpp"
+#include "optimization/MrHyDE_OptVector.hpp"
 
 namespace MrHyDE {
   

--- a/src/managers/postprocessManager.hpp
+++ b/src/managers/postprocessManager.hpp
@@ -11,20 +11,24 @@
 
 #include "trilinos.hpp"
 #include "preferences.hpp"
-#include "meshInterface.hpp"
-#include "physicsInterface.hpp"
-#include "discretizationInterface.hpp"
-//#include "functionManager.hpp"
-#include "assemblyManager.hpp"
-#include "parameterManager.hpp"
-#include "multiscaleManager.hpp"
-#include "linearAlgebraInterface.hpp"
-#include "MrHyDE_OptVector.hpp"
-#include "postprocessTools.hpp"
+
+#include "tools/postprocessTools.hpp"
+
+#include "interfaces/meshInterface.hpp"
+#include "interfaces/physicsInterface.hpp"
+#include "interfaces/discretizationInterface.hpp"
+#include "interfaces/linearAlgebraInterface.hpp"
 
 #if defined(MrHyDE_ENABLE_FFTW)
 #include "fftInterface.hpp"
 #endif
+
+//#include "functionManager.hpp"
+#include "assemblyManager.hpp"
+#include "parameterManager.hpp"
+#include "multiscaleManager.hpp"
+
+#include "optimization/MrHyDE_OptVector.hpp"
 
 namespace MrHyDE {
   

--- a/src/managers/solverManager.hpp
+++ b/src/managers/solverManager.hpp
@@ -11,15 +11,18 @@
 
 #include "trilinos.hpp"
 #include "preferences.hpp"
-#include "meshInterface.hpp"
-#include "physicsInterface.hpp"
+
+#include "interfaces/meshInterface.hpp"
+#include "interfaces/physicsInterface.hpp"
+#include "interfaces/discretizationInterface.hpp"
+#include "interfaces/linearAlgebraInterface.hpp"
+
 #include "multiscaleManager.hpp"
-#include "discretizationInterface.hpp"
 #include "assemblyManager.hpp"
 #include "parameterManager.hpp"
 #include "postprocessManager.hpp"
-#include "solutionStorage.hpp"
-#include "linearAlgebraInterface.hpp"
+
+#include "tools/solutionStorage.hpp"
 
 namespace MrHyDE {
   

--- a/src/physics/physicsBase.hpp
+++ b/src/physics/physicsBase.hpp
@@ -11,9 +11,9 @@
 
 #include "trilinos.hpp"
 #include "preferences.hpp"
-#include "workset.hpp"
-#include "functionManager.hpp"
-#include "compressedView.hpp"
+#include "tools/workset.hpp"
+#include "managers/functionManager.hpp"
+#include "tools/compressedView.hpp"
 
 namespace MrHyDE {
   

--- a/src/preferences.hpp
+++ b/src/preferences.hpp
@@ -124,6 +124,9 @@ typedef Kokkos::HostSpace HostMem;
 #endif
 
 
+// TODO: Fix this
+// #define MrHyDE_HAVE_TRILINOS14
+
 // Trilinos 14 and later redefines the Kokkos::Compat wrappers in Tpetra to Tpetra::KokkosCompat
 // Define intermediate namespaces here to clean up the logic for the HostNode,AssemblyNode,SolverNode
 #ifdef MrHyDE_HAVE_TRILINOS14

--- a/src/preferences.hpp
+++ b/src/preferences.hpp
@@ -124,9 +124,6 @@ typedef Kokkos::HostSpace HostMem;
 #endif
 
 
-// TODO: Fix this
-// #define MrHyDE_HAVE_TRILINOS14
-
 // Trilinos 14 and later redefines the Kokkos::Compat wrappers in Tpetra to Tpetra::KokkosCompat
 // Define intermediate namespaces here to clean up the logic for the HostNode,AssemblyNode,SolverNode
 #ifdef MrHyDE_HAVE_TRILINOS14

--- a/src/subgrid/subgridModel.hpp
+++ b/src/subgrid/subgridModel.hpp
@@ -11,7 +11,7 @@
 
 #include "trilinos.hpp"
 #include "preferences.hpp"
-#include "solutionStorage.hpp"
+#include "tools/solutionStorage.hpp"
 
 namespace MrHyDE {
   

--- a/src/tools/boundaryGroup.hpp
+++ b/src/tools/boundaryGroup.hpp
@@ -13,7 +13,7 @@
 #include "preferences.hpp"
 #include "workset.hpp"
 #include "groupMetaData.hpp"
-#include "discretizationInterface.hpp"
+#include "interfaces/discretizationInterface.hpp"
 #include "compressedView.hpp"
 
 #include <iostream>     

--- a/src/tools/data.hpp
+++ b/src/tools/data.hpp
@@ -12,7 +12,7 @@
 #include "trilinos.hpp"
 #include <iostream>     
 #include <iterator>     
-#include "CompadreInterface.hpp"
+#include "interfaces/CompadreInterface.hpp"
 
 namespace MrHyDE {
   

--- a/src/tools/group.hpp
+++ b/src/tools/group.hpp
@@ -12,9 +12,9 @@
 #include "trilinos.hpp"
 #include "preferences.hpp"
 #include "workset.hpp"
-#include "subgridModel.hpp"
+#include "subgrid/subgridModel.hpp"
 #include "groupMetaData.hpp"
-#include "discretizationInterface.hpp"
+#include "interfaces/discretizationInterface.hpp"
 #include "compressedView.hpp"
 
 #include <iostream>     

--- a/src/tools/groupMetaData.hpp
+++ b/src/tools/groupMetaData.hpp
@@ -11,9 +11,9 @@
 
 #include "trilinos.hpp"
 #include "preferences.hpp"
-#include "physicsBase.hpp"
-#include "physicsInterface.hpp"
-#include "sparse3DView.hpp"
+#include "physics/physicsBase.hpp"
+#include "interfaces/physicsInterface.hpp"
+#include "tools/sparse3DView.hpp"
 
 #include <iostream>     
 #include <iterator>     

--- a/src/trilinos.hpp
+++ b/src/trilinos.hpp
@@ -28,7 +28,7 @@
 
 // Kokkos include
 #include "Kokkos_Core.hpp"
-#include "kokkosTools.hpp"
+#include "tools/kokkosTools.hpp"
 
 // Sacado
 #include "Sacado.hpp"


### PR DESCRIPTION
Sorry for all of this unsolicited code, but I'm working with MrHyDE and would really like the ability to tap into is as a library and use it with external UQ tooling that I work on. Some reasons:
- While one could make all of the tooling internal to MrHyDE, that takes a lot of setup for each individual library.
- I could theoretically use File IO for a lot of this stuff (e.g. create an `input.yaml` and change it using Python/Julia/etc every time I want to change one particular parameter of the model), that's massively wasteful. In particular, that would require MrHyDE to construct and load a mesh at every iteration. If I'm running MCMC or something on a simpler PDE, the meshing could easily compare with (if not dominate) the cost of solving the actual problem.
- This would allow a much easier linking to a higher level language (e.g. Python/Julia)

This PR is more-or-less a fully-functional proof of concept, as any external library would need pretty detailed knowledge of the workings of MrHyDE. The idea is that, if this is merged, I'd go back in and instrument some kind of `externalInterface.hpp` or something, which would basically emulate the functionality in `driver.cpp` but wrap a bunch of the managers in a big object and allow you to change the object in "easier" ways. In particular, at least to get started, it would have:
- a function to set parameter values
- a function to run the solve
- a function to retrieve results from the analysis/postprocess (e.g. sensor data, adjoints, etc)

At least at first, I wouldn't bother interfacing with the UQ/optimization managers, because that would be a little too onerous. While I may be myopic, this would cover 80-90% of any use-cases for the library: allow external tools to access results to run custom postprocessing that would be out-of-scope for MrHyDE.

Notes on the PR:
- ***This does not affect the `mrhyde` executable in any way*** (to my knowledge)
- Adds an option `MrHyDE_BUILD_SHARED_LIBS`, which turns on/off the building of the shared library
- Adds cmake packaging so that an external library can just use `find_package(MrHyDE REQUIRED)` and `target_link_libraries(<target_name> MrHyDE::mrhyde_lib)` with, e.g., `cmake -DMrHyDE_ROOT=<path_to_install_prefix>`
- Most changes come from modifying pathing to be relative (instead of relying on `include` statements within the configuration). This is necessary for external linkage.
- Since this is just a proof-of-concept, the shared library won't work with all configurations of `MrHyDE` (hence the ability to turn it off), but it works with the default configuration.
- Unfortunately, it basically builds the same object files twice (once for the `mrhyde` binary, and once for the library). I'm not sure if there's a good way to consolidate those. Advice is appreciated

I'm open to any thoughts/advice/changes!