### PR TITLE
Fix for divergent gradients for different spellings of objective function (E[x]^2 vs E[x]*E[x])

### DIFF
--- a/src/managers/function/functionManager_evaluate.hpp
+++ b/src/managers/function/functionManager_evaluate.hpp
@@ -950,15 +950,48 @@ void FunctionManager<EvalT>::evaluateOpSToV(T1 data, T2 & tdata_, const string &
     });
   }
   else if (op == "power") {
-    parallel_for("funcman evaluate power",
-                 TeamPolicy<AssemblyExec>(dim0, Kokkos::AUTO, VECTORSIZE),
-                 MRHYDE_LAMBDA (TeamPolicy<AssemblyExec>::member_type team ) {
-      int elem = team.league_rank();
-      size_t dim1 = data.extent(1);
-      for (size_type pt=team.team_rank(); pt<dim1; pt+=team.team_size() ) {
-        data(elem,pt) = pow(data(elem,pt),tdata);
+    // For small integer exponents (2-4), use repeated multiply. pow on tiny
+    // bases yielded junk AD derivatives; the unrolled path avoids that
+    // division-based rule while keeping the same result.
+    double pscalar = 0.0;
+    bool useUnrolled = false;
+    if constexpr (std::is_arithmetic<T2>::value) {
+      pscalar = static_cast<double>(tdata);
+      double rounded = std::round(pscalar);
+      if (rounded >= 2.0 && rounded <= 4.0
+          && std::abs(pscalar - rounded) < 1.0e-12) {
+        useUnrolled = true;
+        pscalar = rounded;
       }
-    });
+    }
+    if (useUnrolled) {
+      const int n = static_cast<int>(pscalar);
+      parallel_for("funcman evaluate power int",
+                   TeamPolicy<AssemblyExec>(dim0, Kokkos::AUTO, VECTORSIZE),
+                   MRHYDE_LAMBDA (TeamPolicy<AssemblyExec>::member_type team ) {
+        int elem = team.league_rank();
+        size_t dim1 = data.extent(1);
+        for (size_type pt=team.team_rank(); pt<dim1; pt+=team.team_size() ) {
+          auto base = data(elem,pt);
+          auto acc = base;
+          for (int j=1; j<n; ++j) {
+            acc = acc * base;
+          }
+          data(elem,pt) = acc;
+        }
+      });
+    }
+    else {
+      parallel_for("funcman evaluate power",
+                   TeamPolicy<AssemblyExec>(dim0, Kokkos::AUTO, VECTORSIZE),
+                   MRHYDE_LAMBDA (TeamPolicy<AssemblyExec>::member_type team ) {
+        int elem = team.league_rank();
+        size_t dim1 = data.extent(1);
+        for (size_type pt=team.team_rank(); pt<dim1; pt+=team.team_size() ) {
+          data(elem,pt) = pow(data(elem,pt),tdata);
+        }
+      });
+    }
   }
   else if (op == "sin") {
     parallel_for("funcman evaluate sin",


### PR DESCRIPTION
This PR aims to address the issue described in #15.
 
Sacado's `PowerOp::Scalar` at [`Sacado_Fad_Exp_Ops.hpp:980-985`](https://github.com/trilinos/Trilinos/blob/77c7ad90c149c1f98f29150fb6aa4634c0327d44/packages/sacado/src/new_design/Sacado_Fad_Exp_Ops.hpp#L980-L985) evaluates the constant-exponent power rule as `c * (a'/a) * pow(a, c)`. That is mathematically identical to `SFad*SFad's 2*a*a'` for c=2, but the two floating-point orderings differ by 1-2 ULPs per derivative slot on each quadrature point call.

On the 1D and 2D Maxwell optimal-control problems, that per-quadrature-point ~1 ULP difference produces up to 10% relative disagreement in the iter-0 gradient (||g_pow - g_mul|| / ||g_mul||) at DoFs where the true adjoint signal is small, the pre-wave portion of the observation region, before the physical wave arrives. Once the physical signal reaches those DOFs, the disagreement drops to machine precision (described in #15). In L-BFGS this shows up as alpha=0 line-search failures as the mesh is refined, when the pow version of the objective is used.

Standalone Sacado (no Kokkos, no MrHyDE) reproduces the 1-2 ULP difference, but I have not reproduced the amplified aggregate effect outside of the full adjoint pipeline.

The proposed fix unrolls ^n into repeated multiplication when the exponent is a small integer (n in {2, 3, 4}). Larger or non-integer exponents still take the std::pow path. Obviously, the user can unroll it manually in the deck-file, but some users may not be aware of use case where it genuinely important to do so, hence the PR.  

## Unroll example for objective string

```
# c      path        Sacado expression
  1.00   pow         pow(base, 1)
  1.10   pow         pow(base, 1.10)
  2.00   unrolled    base * base
  3.00   unrolled    (base * base) * base
  4.00   unrolled    ((base * base) * base) * base
  5.00   pow         pow(base, 5)
  2.50   pow         pow(base, 2.50)
```