### PR TITLE
Memory leaks

### DIFF
--- a/regression/functions/Valid/mrhyde.gold
+++ b/regression/functions/Valid/mrhyde.gold
@@ -11,7 +11,7 @@ DOFManager Field Information:
       "q" is field ID 3
  - Processor 0 has 4 elements
  - Processor 0 has 8 boundary elements
- - Processor 0 is using 0.005736 MB to store volumetric data
+ - Processor 0 is using 0.005224 MB to store volumetric data
  - Processor 0 is using 0 MB to store face data
  - Processor 0 is using 0.00496 MB to store boundary data
 

--- a/src/interfaces/discretization/discretizationInterface_basis.hpp
+++ b/src/interfaces/discretization/discretizationInterface_basis.hpp
@@ -493,11 +493,18 @@ void DiscretizationInterface::getPhysicalVolumetricBasis(Teuchos::RCP<GroupMetaD
         
         {
           Teuchos::TimeMonitor localtimer(*phys_vol_data_basis_curl_curl_timer);
-        
+
+          // 2D curl is scalar; 3D curl is vector.
           DRV bcurl1, bcurl2;
-          bcurl1 = DRV("basis",numElem,numb,numip,dimension);
-          bcurl2 = DRV("basis tmp",numElem,numb,numip,dimension);
-          
+          if (dimension == 2) {
+            bcurl1 = DRV("basis",numElem,numb,numip);
+            bcurl2 = DRV("basis tmp",numElem,numb,numip);
+          }
+          else {
+            bcurl1 = DRV("basis",numElem,numb,numip,dimension);
+            bcurl2 = DRV("basis tmp",numElem,numb,numip,dimension);
+          }
+
           FuncTools::HCURLtransformCURL(bcurl1, jacobian, jacobianDet, groupData->ref_basis_curl[i]);
           if (apply_orientations && groupData->basis_pointers[i]->requireOrientation()) {
             OrientTools::modifyBasisByOrientation(bcurl2, bcurl1, orientation,
@@ -506,8 +513,16 @@ void DiscretizationInterface::getPhysicalVolumetricBasis(Teuchos::RCP<GroupMetaD
           else {
             bcurl2 = bcurl1;
           }
-          basis_curl_vals = View_Sc4("basis curl values", numElem, numb, numip, dimension);
-          Kokkos::deep_copy(basis_curl_vals, bcurl2);
+          // Keep rank-4 storage; trailing dim is 1 in 2D.
+          if (dimension == 2) {
+            basis_curl_vals = View_Sc4("basis curl values", numElem, numb, numip, 1);
+            auto basis_curl_slice = Kokkos::subview(basis_curl_vals, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL(), 0);
+            Kokkos::deep_copy(basis_curl_slice, bcurl2);
+          }
+          else {
+            basis_curl_vals = View_Sc4("basis curl values", numElem, numb, numip, dimension);
+            Kokkos::deep_copy(basis_curl_vals, bcurl2);
+          }
         }
       }
       basis.push_back(basis_vals);

--- a/src/interfaces/physics/physicsInterface.hpp
+++ b/src/interfaces/physics/physicsInterface.hpp
@@ -263,7 +263,8 @@ public:
    * @return std::vector<View_Sc2>  Vector of 3 2D arrays for (x,y,z) components.
    */
   std::vector<View_Sc2> getDirichletVector(const int & var, const int & set,
-                                           const int & block, const std::string & sidename);
+                                           const int & block, const std::string & sidename,
+                                           const int & boundary_numElem);
 
 
   /////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/interfaces/physics/physicsInterface_boundary_conditions.hpp
+++ b/src/interfaces/physics/physicsInterface_boundary_conditions.hpp
@@ -71,22 +71,22 @@ View_Sc2 PhysicsInterface::getDirichlet(const int & var,
 std::vector<View_Sc2> PhysicsInterface::getDirichletVector(const int & var,
                                                            const int & set,
                                                            const int & block,
-                                                           const std::string & sidename) {
-  
+                                                           const std::string & sidename,
+                                                           const int & boundary_numElem) {
+  // Use boundary_numElem to match side-ip view extents.
   std::vector<View_Sc2> dvals_vec(3);
   string varname = var_list[set][block][var];
   std::vector<string> components = {"x", "y", "z"};
-  
-  // check if vector component functions exist (e.g., "Dirichlet Ex bottom")
+
   bool has_components = function_managers[block]->hasFunction("Dirichlet " + varname + "x " + sidename);
-  
+
   if (has_components) {
     // use component-wise Dirichlet data
     for (size_t d=0; d<3; d++) {
       string label = "Dirichlet " + varname + components[d] + " " + sidename;
       if (function_managers[block]->hasFunction(label)) {
         auto tdvals = function_managers[block]->evaluate(label, "side ip");
-        View_Sc2 dvals("dirichlet component", function_managers[block]->num_elem_, function_managers[block]->num_ip_side_);
+        View_Sc2 dvals("dirichlet component", boundary_numElem, function_managers[block]->num_ip_side_);
         parallel_for("physics fill Dirichlet vector component",
                      RangePolicy<AssemblyExec>(0,dvals.extent(0)),
                      MRHYDE_LAMBDA (const int e) {
@@ -98,7 +98,7 @@ std::vector<View_Sc2> PhysicsInterface::getDirichletVector(const int & var,
       }
       else {
         // use zero, if component not specified
-        View_Sc2 dvals("dirichlet component zero", function_managers[block]->num_elem_, function_managers[block]->num_ip_side_);
+        View_Sc2 dvals("dirichlet component zero", boundary_numElem, function_managers[block]->num_ip_side_);
         Kokkos::deep_copy(dvals, 0.0);
         dvals_vec[d] = dvals;
       }
@@ -108,7 +108,7 @@ std::vector<View_Sc2> PhysicsInterface::getDirichletVector(const int & var,
     // fall back to scalar Dirichlet data broadcast to all components
     auto tdvals = function_managers[block]->evaluate("Dirichlet " + varname + " " + sidename, "side ip");
     for (size_t d=0; d<3; d++) {
-      View_Sc2 dvals("dirichlet component broadcast", function_managers[block]->num_elem_, function_managers[block]->num_ip_side_);
+      View_Sc2 dvals("dirichlet component broadcast", boundary_numElem, function_managers[block]->num_ip_side_);
       parallel_for("physics fill Dirichlet broadcast",
                    RangePolicy<AssemblyExec>(0,dvals.extent(0)),
                    MRHYDE_LAMBDA (const int e) {
@@ -119,7 +119,7 @@ std::vector<View_Sc2> PhysicsInterface::getDirichletVector(const int & var,
       dvals_vec[d] = dvals;
     }
   }
-  
+
   return dvals_vec;
 }
 

--- a/src/managers/assembly/assemblyManager_constraints.hpp
+++ b/src/managers/assembly/assemblyManager_constraints.hpp
@@ -336,7 +336,9 @@ View_Sc2 AssemblyManager<Node>::getDirichletBoundary(const int & block, const si
       }
       else if (btype == "HCURL"){
         // Get vector-valued Dirichlet data E = (Ex, Ey, Ez)
-        auto dip_vec = groupData[block]->physics->getDirichletVector(n, set, groupData[block]->my_block, boundary_groups[block][grp]->sidename);
+        auto dip_vec = groupData[block]->physics->getDirichletVector(n, set, groupData[block]->my_block,
+                                                                     boundary_groups[block][grp]->sidename,
+                                                                     boundary_groups[block][grp]->numElem);
         View_Sc2 dip_x = dip_vec[0];
         View_Sc2 dip_y = dip_vec[1];
         View_Sc2 dip_z = dip_vec[2];

--- a/src/managers/postprocess/postprocessManager_objective_gradient.hpp
+++ b/src/managers/postprocess/postprocessManager_objective_gradient.hpp
@@ -1111,10 +1111,10 @@ void PostprocessManager<Node>::computeObjectiveGradState(const size_t &set,
     sol_kv.push_back(vec_dev);
   }
 
-  // Grab slices of Kokkos Views and push to AssembleDevice one time (each)
+  // paramLIDs are overlapped; pull the overlapped discretized params.
   vector<Kokkos::View<ScalarT *, AssemblyDevice>> params_kv;
 
-  auto Psol = params->getDiscretizedParams();
+  auto Psol = params->getDiscretizedParamsOver();
   auto p_kv = Psol->template getLocalView<LA_device>(Tpetra::Access::ReadWrite);
   auto pslice = Kokkos::subview(p_kv, Kokkos::ALL(), 0);
 

--- a/src/managers/postprocess/postprocessManager_sensors.hpp
+++ b/src/managers/postprocess/postprocessManager_sensors.hpp
@@ -1007,8 +1007,14 @@ void PostprocessManager<Node>::locateSensorPoints(const int & block,
         for (size_type p = 0; p < nodebox.extent(0); ++p)
         {
           double xbuff = 0.1 * (nodebox(p, 0, 1) - nodebox(p, 0, 0));
-          double ybuff = 0.1 * (nodebox(p, 1, 1) - nodebox(p, 1, 0));
-          double zbuff = 0.1 * (nodebox(p, 2, 1) - nodebox(p, 2, 0));
+          double ybuff = 0.0;
+          double zbuff = 0.0;
+          if (dimension > 1) {
+            ybuff = 0.1 * (nodebox(p, 1, 1) - nodebox(p, 1, 0));
+          }
+          if (dimension > 2) {
+            zbuff = 0.1 * (nodebox(p, 2, 1) - nodebox(p, 2, 0));
+          }
           bool proceed = true;
           if (spts_host(pt, 0) < nodebox(p, 0, 0) - xbuff || spts_host(pt, 0) > nodebox(p, 0, 1) + xbuff)
           {

--- a/src/physics/maxwells_fp.cpp
+++ b/src/physics/maxwells_fp.cpp
@@ -573,7 +573,7 @@ void maxwells_fp<EvalT>::boundaryResidual() {
   }
   
   
-  for (size_type e=0; e<res.extent(0); e++) { // elements in workset
+  for (size_type e=0; e<wkset->numElem; e++) { // elements on this boundary side
     
     for( size_type k=0; k<ip_x.extent(1); k++) {
       

--- a/src/subgrid/subgridDtN2.cpp
+++ b/src/subgrid/subgridDtN2.cpp
@@ -833,18 +833,21 @@ void SubGridDtN2::subgridSolver(View_Sc3 coarse_fwdsoln,
                         coarse_prevsoln.extent(1),
                         coarse_prevsoln.extent(2),
                         coarse_prevsoln.extent(3));
-                        
-  parallel_for("subgrid set coarse sol",
-               RangePolicy<AssemblyExec>(0,coarse_uprev.extent(0)),
-               MRHYDE_LAMBDA (const size_type e ) {
-    for (size_type i=0; i<coarse_uprev.extent(1); i++) {
-      for (size_type j=0; j<coarse_uprev.extent(2); j++) {
-        for (size_type k=0; k<coarse_uprev.extent(3); k++) {
-          coarse_uprev(e,i,j,k) = coarse_prevsoln(macroIDs(e),i,j,k);
+
+  // Steady-state uses a dummy coarse_prevsoln; copy only for transient solves.
+  if (isTransient) {
+    parallel_for("subgrid set coarse sol",
+                 RangePolicy<AssemblyExec>(0,coarse_uprev.extent(0)),
+                 MRHYDE_LAMBDA (const size_type e ) {
+      for (size_type i=0; i<coarse_uprev.extent(1); i++) {
+        for (size_type j=0; j<coarse_uprev.extent(2); j++) {
+          for (size_type k=0; k<coarse_uprev.extent(3); k++) {
+            coarse_uprev(e,i,j,k) = coarse_prevsoln(macroIDs(e),i,j,k);
+          }
         }
       }
-    }
-  });
+    });
+  }
   
   if (isAdjoint) {
     coarse_phi = Kokkos::View<ScalarT***,AssemblyDevice>("local phi",groups[macrogrp][0]->numElem,
@@ -864,11 +867,14 @@ void SubGridDtN2::subgridSolver(View_Sc3 coarse_fwdsoln,
   // Extract the previous solution as the initial guess/condition for subgrid problems
   Teuchos::RCP<SG_MultiVector> curr_adjsoln, prev_fwdsoln, prev_adjsoln;
   
-  // Solve the local subgrid problem and fill in the coarse macrowkset->res;
+  // Psol may be empty when no discretized params; pass null RCP then.
+  Teuchos::RCP<SG_MultiVector> psol_arg = Psol.empty()
+      ? Teuchos::RCP<SG_MultiVector>()
+      : Psol[0];
   sub_solver->solve(coarse_u, coarse_uprev, coarse_phi,
                     prev_soln[macrogrp], curr_soln[macrogrp], stage_soln[macrogrp],
                     prev_adjsoln, curr_adjsoln,
-                    Psol[0],
+                    psol_arg,
                     time, isTransient, isAdjoint, compute_jacobian,
                     compute_sens, num_active_params, compute_disc_sens, compute_aux_sens,
                     macrowkset, macrogrp, macroelemindex, subgradient, store_adjPrev);

--- a/src/tools/Intrepid2_HFACE_HEX_In_FEM.hpp
+++ b/src/tools/Intrepid2_HFACE_HEX_In_FEM.hpp
@@ -133,7 +133,8 @@ namespace Intrepid2 {
           
           switch (opType) {
             case OPERATOR_VALUE : {
-              auto output = Kokkos::subview( _outputValues, Kokkos::ALL(), ptRange, Kokkos::ALL() );
+              // HFACE is scalar-valued, so use rank-2 output.
+              auto output = Kokkos::subview( _outputValues, Kokkos::ALL(), ptRange );
               Serial<opType>::getValues( output, input, work, _vinvLine);
               break;
             }

--- a/src/tools/Intrepid2_HFACE_HEX_In_FEMdef.hpp
+++ b/src/tools/Intrepid2_HFACE_HEX_In_FEMdef.hpp
@@ -98,7 +98,7 @@ namespace Intrepid2 {
           // left side (x=-1) first
           {
             bool on_edge = false;
-            if (std::abs(input_x(0)+1.0)<1.0e-12) {
+            if (std::abs(input_x.access(0)+1.0)<1.0e-12) {
               on_edge = true;
             }
             if (on_edge) {
@@ -127,7 +127,7 @@ namespace Intrepid2 {
           // bottom side (y=-1)
           {
             bool on_edge = false;
-            if (std::abs(input_y(0)+1.0)<1.0e-12) {
+            if (std::abs(input_y.access(0)+1.0)<1.0e-12) {
               on_edge = true;
             }
             
@@ -156,7 +156,7 @@ namespace Intrepid2 {
           // right side (x=1)
           {
             bool on_edge = false;
-            if (std::abs(input_x(0)-1.0)<1.0e-12) {
+            if (std::abs(input_x.access(0)-1.0)<1.0e-12) {
               on_edge = true;
             }
             if (on_edge) {
@@ -184,7 +184,7 @@ namespace Intrepid2 {
           // top side (y=1)
           {
             bool on_edge = false;
-            if (std::abs(input_y(0)-1.0)<1.0e-12) {
+            if (std::abs(input_y.access(0)-1.0)<1.0e-12) {
               on_edge = true;
             }
             
@@ -213,7 +213,7 @@ namespace Intrepid2 {
           // front side (z=-1)
           {
             bool on_edge = false;
-            if (std::abs(input_z(0)+1.0)<1.0e-12) {
+            if (std::abs(input_z.access(0)+1.0)<1.0e-12) {
               on_edge = true;
             }
             
@@ -242,7 +242,7 @@ namespace Intrepid2 {
           // back side (z=1)
           {
             bool on_edge = false;
-            if (std::abs(input_z(0)-1.0)<1.0e-12) {
+            if (std::abs(input_z.access(0)-1.0)<1.0e-12) {
               on_edge = true;
             }
             

--- a/src/tools/Intrepid2_HFACE_QUAD_In_FEM.hpp
+++ b/src/tools/Intrepid2_HFACE_QUAD_In_FEM.hpp
@@ -135,7 +135,8 @@ namespace Intrepid2 {
           
           switch (opType) {
             case OPERATOR_VALUE : {
-              auto output = Kokkos::subview( _outputValues, Kokkos::ALL(), ptRange, Kokkos::ALL() );
+              // HFACE is scalar-valued, so use rank-2 output.
+              auto output = Kokkos::subview( _outputValues, Kokkos::ALL(), ptRange );
               Serial<opType>::getValues( output, input, work, _vinvLine);
               break;
             }

--- a/src/tools/Intrepid2_HFACE_QUAD_In_FEMdef.hpp
+++ b/src/tools/Intrepid2_HFACE_QUAD_In_FEMdef.hpp
@@ -91,7 +91,7 @@ namespace Intrepid2 {
           // left side (x=-1) first
           {
             bool on_edge = false;
-            if (std::abs(input_x(0)+1.0)<1.0e-12) {
+            if (std::abs(input_x.access(0)+1.0)<1.0e-12) {
               on_edge = true;
             }
             if (on_edge) {
@@ -117,7 +117,7 @@ namespace Intrepid2 {
           // bottom side (y=-1)
           {
             bool on_edge = false;
-            if (std::abs(input_y(0)+1.0)<1.0e-12) {
+            if (std::abs(input_y.access(0)+1.0)<1.0e-12) {
               on_edge = true;
             }
             
@@ -145,7 +145,7 @@ namespace Intrepid2 {
           // right side (x=1)
           {
             bool on_edge = false;
-            if (std::abs(input_x(0)-1.0)<1.0e-12) {
+            if (std::abs(input_x.access(0)-1.0)<1.0e-12) {
               on_edge = true;
             }
             if (on_edge) {
@@ -171,7 +171,7 @@ namespace Intrepid2 {
           // top side (y=1)
           {
             bool on_edge = false;
-            if (std::abs(input_y(0)-1.0)<1.0e-12) {
+            if (std::abs(input_y.access(0)-1.0)<1.0e-12) {
               on_edge = true;
             }
             

--- a/src/tools/Intrepid2_HFACE_TET_In_FEM.hpp
+++ b/src/tools/Intrepid2_HFACE_TET_In_FEM.hpp
@@ -140,7 +140,8 @@ namespace Intrepid2 {
           
           switch (opType) {
             case OPERATOR_VALUE : {
-              auto output = Kokkos::subview( _outputValues, Kokkos::ALL(), ptRange, Kokkos::ALL() );
+              // HFACE is scalar-valued, so use rank-2 output.
+              auto output = Kokkos::subview( _outputValues, Kokkos::ALL(), ptRange );
               Serial<opType>::getValues( output, input, work, _vinvTri);
               break;
             }

--- a/src/tools/Intrepid2_HFACE_TRI_In_FEM.hpp
+++ b/src/tools/Intrepid2_HFACE_TRI_In_FEM.hpp
@@ -133,7 +133,8 @@ namespace Intrepid2 {
           
           switch (opType) {
             case OPERATOR_VALUE : {
-              auto output = Kokkos::subview( _outputValues, Kokkos::ALL(), ptRange, Kokkos::ALL() );
+              // HFACE is scalar-valued, so use rank-2 output.
+              auto output = Kokkos::subview( _outputValues, Kokkos::ALL(), ptRange );
               Serial<opType>::getValues( output, input, work, _vinvLine);
               break;
             }

--- a/src/tools/Intrepid2_HFACE_TRI_In_FEMdef.hpp
+++ b/src/tools/Intrepid2_HFACE_TRI_In_FEMdef.hpp
@@ -95,7 +95,7 @@ namespace Intrepid2 {
           // left side (x=0) first
           {
             bool on_edge = false;
-            if (std::abs(input_x(0)-0.0)<1.0e-12) {
+            if (std::abs(input_x.access(0)-0.0)<1.0e-12) {
               on_edge = true;
             }
             if (on_edge) {
@@ -121,7 +121,7 @@ namespace Intrepid2 {
           // bottom side (y=0)
           {
             bool on_edge = false;
-            if (std::abs(input_y(0)-0.0)<1.0e-12) {
+            if (std::abs(input_y.access(0)-0.0)<1.0e-12) {
               on_edge = true;
             }
             
@@ -149,7 +149,7 @@ namespace Intrepid2 {
           // angle side (x+y=1)
           {
             bool on_edge = false;
-            if (std::abs(input_x(0)+input_y(0)-1.0)<1.0e-12) {
+            if (std::abs(input_x.access(0)+input_y.access(0)-1.0)<1.0e-12) {
               on_edge = true;
             }
             if (on_edge) {

--- a/src/tools/workset.cpp
+++ b/src/tools/workset.cpp
@@ -1116,8 +1116,8 @@ void Workset<EvalT>::evaluateSideSolutionField(const int & fieldnum) {
     size_t vindex = side_soln_fields[fieldnum].variable_index_;
     
     View_EvalT2 solvals;
-    size_t uindex = sol_vals_index[side_soln_fields[fieldnum].set_index_][side_soln_fields[fieldnum].variable_index_];
     if (side_soln_fields[fieldnum].variable_type_ == "solution") { // solution
+      size_t uindex = sol_vals_index[side_soln_fields[fieldnum].set_index_][side_soln_fields[fieldnum].variable_index_];
       if (side_soln_fields[fieldnum].derivative_type_ == "time" ) {
         solvals = sol_dot_vals[uindex];
       }


### PR DESCRIPTION
I started this memory leak hunt after seeing sporadic failures in optimized optimal control for Maxwell's equation.
To find potential memory-safety causes, I reran the full suite with a debug AddressSanitizer (ASan) and UndefinedBehaviorSanitizer (UBSan) build.

The fixes in this PR are all versions of the same theme: index and bounds
mismatches. I grouped the changes around that pattern:

- bounds and dimension guards for Kokkos:view access
- boundary-side sizing consistency in residual and Dirichlet paths
- basis/rank consistency for HFACE and HCURL code paths

Many of these seem to be harmless in optimized runs because they often touched
unused values and did not crash immediately. These changes will help to 
eliminate them as future suspects.

Net result from the ASan regression workflow:
- before changes: 95 pass / 45 fail (memory leaks detected)
- final: 140 pass / 0 fail (no observed leaks, identical gold files)

